### PR TITLE
Fix parameters for call with custom params

### DIFF
--- a/snippets/ia-example-media.php
+++ b/snippets/ia-example-media.php
@@ -38,7 +38,7 @@
 		$result = site()->instagramapi($user, $endpoint);
 
 		// with params if you need them
-		// $result = $site->instagramapi($user, 'media/recent', ['count' => 10]);
+		// $result = $site->instagramapi($user, 'media/recent', '', ['count' => 10]);
 	}
 	
 	/////////////////////////////////////


### PR DESCRIPTION
It was missing the third parameter which is the snippet name.